### PR TITLE
Bump versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,13 @@ cabal.sandbox.config
 *.prof
 *.aux
 *.hp
+/.stack-work/
+*.bbl
+*.blg
+*.fdb_latexmk
+*.fls
+*.log
+*.out
+*.pdf
+*.ptb
+*.tex

--- a/TransformersStepByStep.cabal
+++ b/TransformersStepByStep.cabal
@@ -2,11 +2,11 @@ name:                TransformersStepByStep
 version:             0.1.1.0
 synopsis:            Tutorial on monad transformers.
 description:         In this tutorial, we describe how to use monad
-		     transformers in order to incrementally add
-		     functionality to Haskell programs.  It is not a
-		     paper about implementing transformers, but about
-		     using them to write elegant, clean and powerful
-		     programs in Haskell.
+                     transformers in order to incrementally add
+                     functionality to Haskell programs.  It is not a
+                     paper about implementing transformers, but about
+                     using them to write elegant, clean and powerful
+                     programs in Haskell.
 homepage:            https://github.com/mgrabmueller/TransformersStepByStep
 bug-reports:         https://github.com/mgrabmueller/TransformersStepByStep/issues
 license:             BSD3
@@ -25,5 +25,5 @@ source-repository head
 
 executable TransformersStepByStep
   main-is:             Transformers.lhs
-  build-depends:       base >=4.5 && <4.9, mtl >=2.1 && <2.3, containers >=0.4 && <0.6
+  build-depends:       base >=4.5 && <4.12, mtl >=2.1, containers >=0.4
   default-language:    Haskell2010


### PR DESCRIPTION
Bump bounds in Cabal file in order to support more recent versions of GHC.